### PR TITLE
Exit with nonzero status on file path failure

### DIFF
--- a/bin/slint
+++ b/bin/slint
@@ -6,7 +6,7 @@ var slint = require('..');
 var helper = require('../lib/helper');
 var program = require('commander');
 var pkg = require('../package.json');
-var _ = require('lodash');
+var fs = require('fs');
 
 // setup cli
 program
@@ -23,11 +23,22 @@ program
 
 var opts = program.opts();
 
-// if nothing was passed, throw an error
+// if nothing was passed, show usage
 if (!process.argv.slice(2).length || program.args.length > 1) {
   process.exitCode = 1;
   program.help();
 } else {
-  var file = _.first(program.args);
+  var file = program.args[0];
+
+  // check the file actually exists, if its not a url
+  if (!file.startsWith('http')) {
+    try {
+      fs.accessSync(file, fs.constants.R_OK);
+    } catch (e) {
+      process.exitCode = 1;
+      console.log('Couldn\'t read the file provided')
+    }
+  }
+
   slint.validate(file, opts);
 }

--- a/test/slint.spec.js
+++ b/test/slint.spec.js
@@ -15,7 +15,7 @@ describe('Running slint', function () {
   });
 
   // nodejs error thrown overwrites status code
-  xit('should return a non-zero exit code if invalid', function (done) {
+  it('should return a non-zero exit code if invalid', function (done) {
     var slint = spawn('node', ['./bin/slint', 'INVALID\ FILE']);
 
     slint.on('close', function (code) {


### PR DESCRIPTION
Fixes the issue called out in #5 and reenabled the test that should of caught this.